### PR TITLE
Improve font and button styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,8 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  font-size: 17px;
+}
+
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter), Arial, Helvetica, sans-serif;
 }
 
 @layer utilities {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
 import './globals.css'
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -14,7 +17,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className={inter.className}>{children}</body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -224,7 +224,7 @@ export default function ClayToolsRecommender() {
             <Button
               onClick={handleSearch}
               disabled={loading || toolsLoading || !query.trim()}
-              className="px-8 py-6 text-lg rounded-xl bg-gray-600 hover:bg-gray-700"
+              className="px-8 py-6 text-lg rounded-xl bg-orange-500 hover:bg-orange-600 text-white"
             >
               <Search className="w-5 h-5 mr-2" />
               Search


### PR DESCRIPTION
## Summary
- use Inter font globally and raise base font size
- apply Inter to the layout
- color the search button orange to match theme

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ce08a8300832092aa3495a7f847e4