### PR TITLE
Handle poor tool recommendations

### DIFF
--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -177,6 +177,18 @@ Analyze the user's request and recommend the most relevant tools.
 
     console.log("Valid recommendations:", validRecommendations.length)
 
+    const MIN_RELEVANCE = 0.3
+    const hasStrongMatch = validRecommendations.some(
+      (rec) => rec!.relevance_score >= MIN_RELEVANCE
+    )
+
+    if (validRecommendations.length === 0 || !hasStrongMatch) {
+      return Response.json({
+        message:
+          "Sorry we couldn't recommend a tool for this use case. You can submit your use case to tanay@claybootcamp.com or check out the whole list of tools at https://remarkable-lily-32f8dd.netlify.app/",
+      })
+    }
+
     return Response.json({ recommendations: validRecommendations })
   } catch (aiError) {
     console.error("OpenAI error:", aiError)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,8 @@ interface Recommendation {
 }
 
 interface RecommendationResponse {
-  recommendations: Recommendation[]
+  recommendations?: Recommendation[]
+  message?: string
 }
 
 export default function ClayToolsRecommender() {
@@ -281,6 +282,16 @@ export default function ClayToolsRecommender() {
             <h3 className="text-xl font-semibold text-gray-900 mb-2">No matching tools found</h3>
             <p className="text-gray-600">Try rephrasing your request or using different keywords.</p>
           </div>
+        )}
+
+        {/* Low Match Message */}
+        {recommendations && !loading && recommendations.message && (
+          <Alert className="mb-8 border-yellow-200 bg-yellow-50">
+            <AlertCircle className="h-4 w-4 text-yellow-600" />
+            <AlertDescription className="text-yellow-800">
+              {recommendations.message}
+            </AlertDescription>
+          </Alert>
         )}
 
         {/* Recommendations */}


### PR DESCRIPTION
## Summary
- check validity of recommendations from OpenAI
- return a helpful message when no strong match is found

## Testing
- `npx --yes next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_686ced75d918832094bc01cb8abc6e5a