### PR TITLE
Improve search area

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -206,27 +206,25 @@ export default function ClayToolsRecommender() {
             Describe your workflow needs and AI will find the perfect tools
           </p>
 
-          <div className="flex flex-col sm:flex-row gap-2 md:gap-4 mb-6">
-            <div className="flex-1 relative">
-              <div className="rounded-xl border-2 border-gray-200 focus-within:border-orange-300 p-4">
-                <span className="block pl-2 pb-2 text-sm md:text-lg select-none">
-                  Today, I want Clay to
-                </span>
-                <Textarea
-                  rows={4}
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  onKeyDown={handleKeyPress}
-                  placeholder="help me find qualified prospects for my startup"
-                  className="w-full text-sm md:text-lg border-none focus-visible:ring-0 focus-visible:ring-offset-0 resize-none"
-                  disabled={loading || toolsLoading}
-                />
-              </div>
+          <div className="space-y-4 mb-6">
+            <div className="rounded-xl border-2 border-gray-200 focus-within:border-orange-300 p-4">
+              <span className="block pl-2 pb-2 text-sm md:text-lg select-none">
+                Today, I want Clay to
+              </span>
+              <Textarea
+                rows={4}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={handleKeyPress}
+                placeholder="help me find qualified prospects for my startup"
+                className="w-full text-sm md:text-lg border-none focus-visible:ring-0 focus-visible:ring-offset-0 resize-none"
+                disabled={loading || toolsLoading}
+              />
             </div>
             <Button
               onClick={handleSearch}
               disabled={loading || toolsLoading || !query.trim()}
-              className="w-full sm:w-auto px-4 py-3 sm:px-8 sm:py-6 text-base sm:text-lg rounded-xl bg-orange-500 hover:bg-orange-600 text-white"
+              className="w-full px-4 py-3 md:px-8 md:py-6 text-base md:text-lg rounded-xl bg-orange-500 hover:bg-orange-600 text-white"
             >
               <Search className="w-5 h-5 mr-2" />
               Search

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Search, Zap, Target, CheckCircle, Sparkles, ExternalLink, AlertCircle } from "lucide-react"
@@ -132,7 +132,7 @@ export default function ClayToolsRecommender() {
   }
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
+    if ((e.key === "Enter" || e.key === "NumpadEnter") && (e.metaKey || e.ctrlKey)) {
       handleSearch()
     }
   }
@@ -206,18 +206,19 @@ export default function ClayToolsRecommender() {
             Describe your workflow needs and AI will find the perfect tools
           </p>
 
-          <div className="flex gap-2 md:gap-4 mb-6">
+          <div className="flex flex-col sm:flex-row gap-2 md:gap-4 mb-6">
             <div className="flex-1 relative">
-              <div className="flex items-center rounded-xl border-2 border-gray-200 focus-within:border-orange-300">
-                <span className="pl-6 text-sm md:text-lg whitespace-nowrap select-none">
+              <div className="rounded-xl border-2 border-gray-200 focus-within:border-orange-300 p-4">
+                <span className="block pl-2 pb-2 text-sm md:text-lg select-none">
                   Today, I want Clay to
                 </span>
-                <Input
+                <Textarea
+                  rows={4}
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
-                  onKeyPress={handleKeyPress}
+                  onKeyDown={handleKeyPress}
                   placeholder="help me find qualified prospects for my startup"
-                  className="flex-1 text-sm md:text-lg py-4 md:py-6 pl-2 pr-4 border-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                  className="w-full text-sm md:text-lg border-none focus-visible:ring-0 focus-visible:ring-offset-0 resize-none"
                   disabled={loading || toolsLoading}
                 />
               </div>
@@ -225,7 +226,7 @@ export default function ClayToolsRecommender() {
             <Button
               onClick={handleSearch}
               disabled={loading || toolsLoading || !query.trim()}
-              className="px-4 py-3 text-base md:px-8 md:py-6 md:text-lg rounded-xl bg-orange-500 hover:bg-orange-600 text-white"
+              className="w-full sm:w-auto px-4 py-3 sm:px-8 sm:py-6 text-base sm:text-lg rounded-xl bg-orange-500 hover:bg-orange-600 text-white"
             >
               <Search className="w-5 h-5 mr-2" />
               Search


### PR DESCRIPTION
## Summary
- make search box multiline
- allow Cmd/Ctrl+Enter to submit query
- stack search elements on small screens

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686cf9994b708320b6b508e20f6d9c29